### PR TITLE
Bolded language when stating a broad knowledge of a language

### DIFF
--- a/osrc/__init__.py
+++ b/osrc/__init__.py
@@ -544,7 +544,7 @@ def get_stats(username):
                       "expert").format(firstname, langs[0][0])
             ls = [float(l[1]) for l in langs]
             if (ls[0] - ls[1]) / sum(ls) < 0.25:
-                sctxt += (" with a surprisingly broad knowledge of {0} "
+                sctxt += (" with a surprisingly broad knowledge of <strong>{0}</strong> "
                           "as well").format(langs[1][0])
             sctxt += ". "
             sctxt += ("The following chart shows the number of contributions "


### PR DESCRIPTION
To reproduce this, follow these steps:
1. Go to http://osrc.dfm.io/Aaron1011.
2. Scroll down to "Aaron is a serious **Python** expert".
3. Note that **Python** is bolded on the page.
4. In the same sentence, see "with a surprisingly broad knowledge of JavaScript as well".
5. Not that JavaScript is not bolded.
