### PR TITLE
Handle comparison of users when both users are actually the same user

### DIFF
--- a/osrc/__init__.py
+++ b/osrc/__init__.py
@@ -598,6 +598,9 @@ def compare(username, other):
     """
     user1, user2 = username.lower(), other.lower()
 
+    if user1 == user2
+        return "Comparing someone to themself does not provide any statistic except that 0 equals 0, which is nontrivial at best."
+
     pipe = flask.g.redis.pipeline()
 
     pipe.zscore("gh:user", user1)


### PR DESCRIPTION
When you compare someone to his/herself, the comparison description makes no sense. This commit fixes the problem.

Great job on the rest of the project!
