### PR TITLE
Get rid of annoying still-underlined space at end of link

### DIFF
--- a/osrc/templates/user.html
+++ b/osrc/templates/user.html
@@ -15,7 +15,7 @@
         <p>
         {{ name }} is <a href="#languages">{{ adjectives|random }}
         {% if usage.languages[0].language in language_list %}
-        {{ language_list[usage.languages[0].language] }} {% else %}
+        {{ language_list[usage.languages[0].language] }}{% else %}
         {{ usage.languages[0].language }} coder{% endif %}</a>
         {%- if usage.languages[0].quantile < 50 %}
         (one of the {{ usage.languages[0].quantile }}% most active


### PR DESCRIPTION
This was really bugging me.

**before**
![screen shot 2013-11-03 at 9 09 41 pm](https://f.cloud.github.com/assets/1410202/1462572/9cc63472-44fe-11e3-8e88-9c72ccc9e291.png)

**after**
![screen shot 2013-11-03 at 9 09 54 pm](https://f.cloud.github.com/assets/1410202/1462571/9caa421c-44fe-11e3-9a24-bb1abf2ba48e.png)
