### PR TITLE
If nothing is typed, don't show 'false'.

### DIFF
--- a/osrc/templates/nav.html
+++ b/osrc/templates/nav.html
@@ -7,7 +7,7 @@
         username
         {% endif %}
     </div>
-    <form action="javascript:goto_user();">
+    <form action="javascript:return goto_user();">
         <input id="username" type="text" placeholder="How about 'mojombo', for example…">
     </form>
 </div>


### PR DESCRIPTION
`onclick=""` handlers require you to return value, otherwise they are printed (probably some old behavior kept for backwards compatibility), and they aren't used to determine whether event failed or not.
