### PR TITLE
Add languages/names to Languages.json

### DIFF
--- a/osrc/languages.json
+++ b/osrc/languages.json
@@ -3,9 +3,16 @@
     "Ruby": "Rubyist",
     "Go": "Gopher",
     "Java": "Javavore",
-    "C": "sysadmin",
+    "C": "low-level hacker",
+    "Shell": "sysadmin",
     "FORTRAN": "old-school hacker",
     "JavaScript": "JavaScripter",
-    "C++": "corporate slave",
-    "R": "useR"
+    "C++": "",
+    "R": "useR",
+    "Scala": "Scalaite",
+    "C#": "C Sharper",
+    "Ada": "DoD contractor",
+    "Haskell": "Haskeller"
+    "Clojure": "Clojurist",
+    "Rust": "Rustic"
 }


### PR DESCRIPTION
- Switched "sysadmin" from C to Shell
- Switched C to "low-level hacker"
- Switched C++ to something less disparaging. This tool
  gauges F/OSS contribution -- implying that anyone is 
  a corporate slave based on language choice only hurts
  community and isn't likely to be accurate, as time of
  day or contribution to organizations would be better
  indicators.
- Added several languages. Took a guess on a few
